### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/NnekaOkpaluba/29706ffa-b261-4476-a248-46b6a052da66/15b968e9-03a0-4f9f-8722-0ac364d523ad/_apis/work/boardbadge/45c95fd2-9c7d-40a4-9e23-39a368699126)](https://dev.azure.com/NnekaOkpaluba/29706ffa-b261-4476-a248-46b6a052da66/_boards/board/t/15b968e9-03a0-4f9f-8722-0ac364d523ad/Microsoft.RequirementCategory)
 # Working in large repositories
 
 This repository is a place with a lot of history.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/NnekaOkpaluba/29706ffa-b261-4476-a248-46b6a052da66/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.